### PR TITLE
cxx: handle .mxx extension for modules

### DIFF
--- a/compiledb/compiler.py
+++ b/compiledb/compiler.py
@@ -23,7 +23,7 @@ class Compiler:
                 "extensions": ["c"]
             },
             "c++": {
-                "extensions": ["cpp", "cc", "cx", "cxx"],
+                "extensions": ["cpp", "cc", "cx", "cxx", "mxx"],
             },
         }
 

--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -29,7 +29,7 @@ from compiledb.utils import run_cmd
 # Internal variables used to parse build log entries
 cc_compile_regex = re.compile(r"^.*-?g?cc-?[0-9.]*$|^.*-?clang-?[0-9.]*$^.*-?cl?exe$|^.*-?(clang-)?cl?(\.exe)?$")
 cpp_compile_regex = re.compile(r"^.*-?[gc]\+\+-?[0-9.]*$|^.*-?clang\+\+-?[0-9.]*$|^.*-?(clang-)?cl?(\.exe)?$")
-file_regex = re.compile(r"^.+\.c$|^.+\.cc$|^.+\.cpp$|^.+\.cxx$|^.+\.s$", re.IGNORECASE)
+file_regex = re.compile(r"^.+\.c$|^.+\.cc$|^.+\.cpp$|^.+\.cxx$|^.+\.mxx$|^.+\.s$", re.IGNORECASE)
 compiler_wrappers = {"ccache", "icecc", "sccache"}
 
 # Leverage `make --print-directory` option


### PR DESCRIPTION
**Register .mxx for build systems (e.g., build2) that can recognize it.** This is useful with [llvm/llvm-project PR #66462](https://github.com/llvm/llvm-project/pull/66462).

*Note that this PR is submitted here, as the main repository is unmaintained, and this one is now the go-to option by default, containing Windows fixes, among others; I hope you don't mind!*